### PR TITLE
fix UnicodeDecodeError due to UTF-16 encoding of partition label

### DIFF
--- a/DiskManager/Fstab/ToolsBackend.py
+++ b/DiskManager/Fstab/ToolsBackend.py
@@ -99,9 +99,9 @@ class ToolsBackend(DiskInfoBase) :
         (sts, result) = self._exec(cmd)
         if not sts :
             for line in result :
-                logging.debug("(udevinfo output) " + line.strip().decode("utf-8"))
+                logging.debug("(udevinfo output) " + line.strip().decode("utf-8", errors="ignore"))
                 try :
-                    device = "/dev/" + re.search("N: (\S+)", line.decode("utf-8")).groups()[0]
+                    device = "/dev/" + re.search("N: (\S+)", line.decode("utf-8", errors="ignore")).groups()[0]
                     dev["DEVICE"] = device
                     logging.debug("-> Found DEVICE : " + device)
                 except AttributeError :
@@ -109,7 +109,7 @@ class ToolsBackend(DiskInfoBase) :
                 # Used for debugging blkid & vol_id :
                 # continue
                 try :
-                    (attr, value) = re.search("E: ID_(\S+)=(.+)", line.decode('utf-8')).groups()
+                    (attr, value) = re.search("E: ID_(\S+)=(.+)", line.decode('utf-8', errors="ignore")).groups()
                     dev[attr] = value
                     logging.debug("-> Found " + attr + " : "+ value)
                 except AttributeError :

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+disk-manager (23.10.01) mx; urgency=medium
+
+  * fix UnicodeDecodeError due to UTF-16 encoding of partition label
+
+ -- fehlix <fehlix@mxlinux.org>  Fri, 20 Oct 2023 18:19:28 -0400
+
 disk-manager (23.09.02) mx; urgency=medium
 
   * adjust missing dump and passno fields for all fstab lines


### PR DESCRIPTION
This exception error:
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe8 in position 16: invalid continuation byte
was raised, when GPT partition label holds non-ascii unicode chars
due to  UTF-16 encoding of partition label.
